### PR TITLE
Use rbac.authorization.k8s.io/v1 for ClusterRole

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubelet-rubber-stamp


### PR DESCRIPTION
rbac.authorization.k8s.io/v1 was released in Kubernetes 1.8, and rbac.authorization.k8s.io/v1beta has been deprecated since 1.17 and is scheduled to be removed in 1.22